### PR TITLE
set logging level & fix test data access

### DIFF
--- a/getting_started_analysis.ipynb
+++ b/getting_started_analysis.ipynb
@@ -75,6 +75,8 @@
    ],
    "source": [
     "import pyaerocom as pya\n",
+    "import logging\n",
+    "logging.getLogger().setLevel(logging.ERROR) # Set level in information outputted by pyaerocom to the console.\n",
     "pya.__version__"
    ]
   },
@@ -120,7 +122,7 @@
     }
    ],
    "source": [
-    "from pyaerocom.testdata_access import initialise\n",
+    "from pyaerocom.access_testdata import initialise\n",
     "initialise()"
    ]
   },
@@ -5150,7 +5152,8 @@
    "hash": "4a7b89c723fcac0e056e2fc6b4f368f26ab64e73796f0dabf71452e7abad2370"
   },
   "kernelspec": {
-   "display_name": "Python 3.9.7 64-bit ('pya': conda)",
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
    "name": "python3"
   },
   "language_info": {
@@ -5163,7 +5166,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.1"
   }
  },
  "nbformat": 4,

--- a/getting_started_setup.ipynb
+++ b/getting_started_setup.ipynb
@@ -22,17 +22,16 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
+     "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/home/jonasg/miniconda3/envs/pyadev/lib/python3.9/site-packages/geonum/__init__.py:26: UserWarning: Plotting of maps etc. is deactivated, please install Basemap\n",
-      "  warn('Plotting of maps etc. is deactivated, please install Basemap')\n"
+      "geopy library is not available. Aeolus data read not enabled\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "'0.12.0.dev1'"
+       "'0.12.2.dev1'"
       ]
      },
      "execution_count": 1,
@@ -42,6 +41,8 @@
    ],
    "source": [
     "import pyaerocom as pya\n",
+    "import logging\n",
+    "logging.getLogger().setLevel(logging.ERROR) # Set level in information outputted by pyaerocom to the console.\n",
     "pya.__version__"
    ]
   },
@@ -171,8 +172,8 @@
     }
    ],
    "source": [
-    "from pyaerocom.testdata_access import TestDataAccess\n",
-    "TestDataAccess().download()"
+    "from pyaerocom.access_testdata import AccessTestData\n",
+    "AccessTestData().download()"
    ]
   },
   {
@@ -753,7 +754,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -767,7 +768,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.2"
+   "version": "3.10.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The addition of the new logging module will by default print everything to the console. Therefore I set the logging level in the two tutorial notebooks. The test_dataaccess module has been renamed and is now up to date with the main_dev branch